### PR TITLE
Add Slalom Build Capability to Consulting Platform

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -101,6 +101,15 @@ capabilities = {
         "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
         "capacity": 20,
         "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+    },
+    "Slalom Build": {
+        "description": "Product strategy, user experience design, and agile product development",
+        "practice_area": "Technology",
+        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+        "certifications": ["Product Management", "Agile Certified Practitioner", "User Experience Design"],
+        "industry_verticals": ["Consumer Products", "FinTech", "HealthTech", "Technology"],
+        "capacity": 45,
+        "consultants": ["marcus.thompson@slalom.com", "david.chen@slalom.com", "jennifer.santos@slalom.com"]
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing Slalom Build capability to the consulting platform, addressing the critical need for product development and digital innovation services.

## Changes
- **New Capability**: Slalom Build - Product strategy, user experience design, and agile product development
- **Practice Area**: Technology
- **Capacity**: 45 hours/week available
- **Initial Consultants**: 3 experienced product consultants ready for client engagement
  - marcus.thompson@slalom.com
  - david.chen@slalom.com
  - jennifer.santos@slalom.com

## Certifications Supported
- Product Management
- Agile Certified Practitioner
- User Experience Design

## Industry Verticals
- Consumer Products
- FinTech
- HealthTech
- Technology

## Resolves
Resolves #6 - Missing Critical Capability: Slalom Build

This change enables consultants to register for Build services and allows the system to support client proposals requiring product development expertise that were due next week.